### PR TITLE
infra: set host to `0.0.0.0` instead of `127.0.0.1`

### DIFF
--- a/deploy/docker/dev/Dockerfile
+++ b/deploy/docker/dev/Dockerfile
@@ -88,7 +88,7 @@ COPY tests/ tests/
 COPY src src/
 RUN poetry install $POETRY_INSTALL_ARGS
 STOPSIGNAL SIGINT
-EXPOSE 8000/tcp
+EXPOSE 8000
 ENTRYPOINT ["tini","--" ]
-CMD [ "litestar","run"]
+CMD [ "litestar","run","--host","0.0.0.0"]
 VOLUME /workspace/app

--- a/deploy/docker/run/Dockerfile
+++ b/deploy/docker/run/Dockerfile
@@ -85,7 +85,7 @@ RUN pip install --quiet --disable-pip-version-check --no-deps --requirement=/tmp
 RUN pip install --quiet --disable-pip-version-check --no-deps /tmp/*.whl
 USER nonroot
 STOPSIGNAL SIGINT
-EXPOSE 8000/tcp
+EXPOSE 8000
 ENTRYPOINT ["tini","--" ]
-CMD [ "litestar","run"]
+CMD [ "litestar","run","--host","0.0.0.0"]
 VOLUME /workspace/app

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -25,7 +25,7 @@ services:
         # remove this to build for production.
         POETRY_INSTALL_ARGS: --with=dev,docs,lint
     image: app:latest-dev
-    command: litestar run --reload
+    command: litestar run --reload --host 0.0.0.0 --port 8000
     restart: always
     <<: *development-volumes
   worker:


### PR DESCRIPTION
This addresses an issue where the services launched in the containers are bound to listen on 127.0.0.1 instead of 0.0.0.0.

This prevented external access to container in most common network configurations.

[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- 

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- 
