### PR TITLE
fix: fix connection reset by peer on tests

### DIFF
--- a/docs/developer_guide/developer_setup.md
+++ b/docs/developer_guide/developer_setup.md
@@ -8,10 +8,10 @@ To begin local development, clone the [litestar-org/litestar-fullstack](https://
 pdm install
 ```
 
-Install optional dependencies using the `--G` flag:
+Install optional dependencies using the `-G` flag:
 
 ```bash
-pdm install --G:all
+pdm install -G:all
 ```
 
 ## Using pip

--- a/tests/docker_service.py
+++ b/tests/docker_service.py
@@ -47,7 +47,7 @@ class DockerServiceRegistry:
         self._running_services: set[str] = set()
         self.docker_ip = self._get_docker_ip()
         self._base_command = [
-            "docker-compose",
+            "docker compose",
             "--file=tests/docker-compose.yml",
             "--project-name=app_pytest",
         ]

--- a/tests/docker_service.py
+++ b/tests/docker_service.py
@@ -77,7 +77,7 @@ class DockerServiceRegistry:
         **kwargs: Any,
     ) -> None:
         if name not in self._running_services:
-            self.run_command("up", "-d", name)
+            self.run_command("up", "-d", name, "--wait")
             self._running_services.add(name)
 
             await wait_until_responsive(


### PR DESCRIPTION
Fix an issue on tests when the postgres image was not really operational due to restarting of the image when creating the database. This caused Connection reset by peers error on first tests directly after the startup of the compose.


### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description


- 

### Close Issue(s)

- 
