### PR TITLE
fix: `structlog` corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,48 +194,6 @@ Using Litestar app from env: 'app.asgi:create_app'
 
 ```
 
-The above command will not start the background workers. Those can be launched separately in another terminal.
-
-Alternately, the `run-all` command will automatically start the background workers in separate processes.
-
-```bash
-❯ app run-all --help
-Using Litestar app from env: 'app.asgi:create_app'
-
- Usage: app run-all [OPTIONS] COMMAND [ARGS]...
-
- Starts the application server & worker in a single command.
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --host                    TEXT                     Host interface to listen  │
-│                                                    on.  Use 0.0.0.0 for all  │
-│                                                    available interfaces.     │
-│                                                    (TEXT)                    │
-│                                                    [default: 0.0.0.0]        │
-│ --port                -p  INTEGER                  Port to bind.   (INTEGER) │
-│                                                    [default: 8000]           │
-│ --http-workers            INTEGER RANGE [1<=x<=7]  The number of HTTP worker │
-│                                                    processes for handling    │
-│                                                    requests.                 │
-│                                                    (INTEGER RANGE)           │
-│                                                    [default: 7; 1<=x<=7]     │
-│ --worker-concurrency      INTEGER RANGE [x>=1]     The number of             │
-│                                                    simultaneous jobs a       │
-│                                                    worker process can        │
-│                                                    execute.                  │
-│                                                    (INTEGER RANGE)           │
-│                                                    [default: 1; x>=1]        │
-│ --reload              -r                           Enable reload             │
-│ --verbose             -v                           Enable verbose logging.   │
-│ --debug               -d                           Enable debugging.         │
-│ --help                -h                           Show this message and     │
-│                                                    exit.                     │
-╰──────────────────────────────────────────────────────────────────────────────╯
-
-```
-
-</details>
-
 ## Installation and Configuration
 
 We have documented the process to help you get the repository up and running.

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -48,27 +48,6 @@ services:
       interval: 2s
       timeout: 3s
       retries: 40
-  localmail:
-    image: mailhog/mailhog:v1.0.0
-    container_name: localmail
-    ports:
-      - "8025:8025"
-  objectstorage:
-    image: minio/minio:latest
-    container_name: objectstorage
-    volumes:
-      - ./media/:/export/app/data
-    ports:
-      - "9000:9000"
-    env_file:
-      - .env.example
-    entrypoint: sh
-    command: -c 'mkdir -p /export/app/data/public && mkdir -p /export/app/data/data && /opt/bin/minio server /export/app/data'
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
 volumes:
   db-data: {}
   cache-data: {}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,12 +24,17 @@ services:
       - "8000:8000"
       - "3006:3006"
     image: app:latest-dev
+    tty: true
+    environment:
+      VITE_USE_SERVER_LIFESPAN: "true" # true in dev or run
+      SAQ_USE_SERVER_LIFESPAN: "false"
     command: litestar run --reload --host 0.0.0.0 --port 8000
     restart: always
     <<: *development-volumes
   worker:
     image: app:latest-dev
     command: litestar workers run
+    tty: true
     restart: always
     <<: *development-volumes
     depends_on:
@@ -37,6 +42,7 @@ services:
         condition: service_healthy
       cache:
         condition: service_healthy
+
     env_file:
       - .env.example
   migrator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,9 @@ services:
         condition: service_healthy
     ports:
       - "8000:8000"
+    environment:
+      VITE_USE_SERVER_LIFESPAN: "false" # true if ssr or separate service
+      SAQ_USE_SERVER_LIFESPAN: "false"
     env_file:
       - .env.example
   worker:

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -18,4 +18,4 @@ cmds = [
 ] # custom install command allows for setting pdm version above
 
 [start]
-cmd = '/opt/venv/bin/app database upgrade --no-prompt && /opt/venv/bin/app run --http-workers 2 --host 0.0.0.0 --port $PORT'
+cmd = '/opt/venv/bin/app database upgrade --no-prompt && /opt/venv/bin/app run --wc 2 --host 0.0.0.0 --port $PORT'

--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,6 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "/opt/venv/bin/app database upgrade --no-prompt && /opt/venv/bin/app run --http-workers 2 --host 0.0.0.0 --port $PORT"
+    "startCommand": "/opt/venv/bin/app database upgrade --no-prompt && /opt/venv/bin/app run --wc 2 --host 0.0.0.0 --port $PORT"
   }
 }

--- a/src/app/lib/log/__init__.py
+++ b/src/app/lib/log/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 from litestar.logging.config import LoggingConfig
+from structlog.dev import RichTracebackFormatter
 
 from app.lib import settings
 
@@ -51,13 +52,13 @@ if sys.stderr.isatty() or "pytest" in sys.modules:  # pragma: no cover
     LoggerFactory: Any = structlog.WriteLoggerFactory
     console_processor = structlog.dev.ConsoleRenderer(
         colors=True,
-        exception_formatter=structlog.dev.plain_traceback,
+        exception_formatter=RichTracebackFormatter(max_frames=1, show_locals=False, width=80),
     )
     default_processors.extend([console_processor])
     stdlib_processors.append(console_processor)
 else:
     LoggerFactory = structlog.BytesLoggerFactory
-    default_processors.extend([msgspec_json_renderer])
+    default_processors.extend([structlog.processors.JSONRenderer(serializer=msgspec_json_renderer)])
 
 
 def configure(processors: Sequence[Processor]) -> None:

--- a/src/app/lib/log/__init__.py
+++ b/src/app/lib/log/__init__.py
@@ -10,10 +10,10 @@ import structlog
 from litestar.logging.config import LoggingConfig
 from structlog.dev import RichTracebackFormatter
 
-from app.lib import settings
+from app.lib import serialization, settings
 
 from . import controller, worker
-from .utils import EventFilter, msgspec_json_renderer
+from .utils import EventFilter, msgspec_json_renderer, msgspec_json_str_renderer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -54,11 +54,12 @@ if sys.stderr.isatty() or "pytest" in sys.modules:  # pragma: no cover
         colors=True,
         exception_formatter=RichTracebackFormatter(max_frames=1, show_locals=False, width=80),
     )
-    default_processors.extend([console_processor])
+    default_processors.append(console_processor)
     stdlib_processors.append(console_processor)
 else:
     LoggerFactory = structlog.BytesLoggerFactory
-    default_processors.extend([structlog.processors.JSONRenderer(serializer=msgspec_json_renderer)])
+    default_processors.append(structlog.processors.JSONRenderer(serializer=msgspec_json_renderer))
+    stdlib_processors.append(structlog.processors.JSONRenderer(serializer=msgspec_json_str_renderer))
 
 
 def configure(processors: Sequence[Processor]) -> None:

--- a/src/app/lib/log/utils.py
+++ b/src/app/lib/log/utils.py
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from app.lib.serialization import _msgspec_json_encoder
 
@@ -25,18 +25,28 @@ if TYPE_CHECKING:
     from structlog.typing import EventDict, WrappedLogger
 
 
-def msgspec_json_renderer(_: WrappedLogger, __: str, event_dict: EventDict) -> bytes:
+def msgspec_json_renderer(event_dict: EventDict, **_: Any) -> bytes:
     """Structlog processor that uses `msgspec` for JSON encoding.
 
     Args:
-        _ ():
-        __ ():
-        event_dict (): The data to be logged.
+         event_dict (): The data to be logged.
 
     Returns:
         The log event encoded to JSON by msgspec.
     """
     return _msgspec_json_encoder.encode(event_dict)
+
+
+def msgspec_json_str_renderer(event_dict: EventDict, **_: Any) -> str:
+    """Structlog processor that uses `msgspec` for JSON encoding.
+
+    Args:
+         event_dict (): The data to be logged.
+
+    Returns:
+        The log event encoded to JSON by msgspec as a string
+    """
+    return _msgspec_json_encoder.encode(event_dict).decode("utf-8")
 
 
 class EventFilter:


### PR DESCRIPTION
fix: the correct a warning that was occurring on the JSON logger (only visible when no TTY).  This warning started appearing in the latest versions of structlog.