### PR TITLE
fix: use `to_dict` to convert to dict

### DIFF
--- a/src/app/cli/commands.py
+++ b/src/app/cli/commands.py
@@ -98,7 +98,7 @@ def create_user(
         )
         async with alchemy.get_session() as db_session:
             users_service = await anext(provide_users_service(db_session))
-            user = await users_service.create(data=obj_in.__dict__, auto_commit=True)
+            user = await users_service.create(data=obj_in.to_dict(), auto_commit=True)
             console.print(f"User created: {user.email}")
 
     console.rule("Create a new application user.")


### PR DESCRIPTION
fixes:
```
(.venv) ~/tmp/litestar-fullstack main*
❯ app users create-user
Using Litestar app from env: 'app.asgi:app'
Loading environment configuration from .env
──────────────────────────────────────────────────────────────────────── Create a new application user. ────────────────────────────────────────────────────────────────────────
Email: darin@darin.com
Full Name: darin
Password: 
Repeat for confirmation: 
Create as superuser?: y
Traceback (most recent call last):
  File "/home/darin/tmp/litestar-fullstack/.venv/bin/app", line 8, in <module>
    sys.exit(run_cli())
             ^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/src/app/__main__.py", line 26, in run_cli
    run_litestar_cli()
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/litestar/__main__.py", line 6, in run_cli
    litestar_group()
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/rich_click/rich_command.py", line 126, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/src/app/cli/commands.py", line 110, in create_user
    anyio.run(_create_user, email, name, password, superuser)
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/anyio/_core/_eventloop.py", line 73, in run
    return async_backend.run(func, args, {}, backend_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2001, in run
    return runner.run(wrapper())
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/.local/share/mise/installs/python/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/darin/.local/share/mise/installs/python/3.12/lib/python3.12/asyncio/base_events.py", line 664, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1989, in wrapper
    return await func(*args)
           ^^^^^^^^^^^^^^^^^
  File "/home/darin/tmp/litestar-fullstack/src/app/cli/commands.py", line 101, in _create_user
    user = await users_service.create(data=obj_in.__dict__, auto_commit=True)
                                           ^^^^^^^^^^^^^^^
AttributeError: 'UserCreate' object has no attribute '__dict__'. Did you mean: '__dir__'?
```

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- 

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- 
