### PR TITLE
fix: use settings db engine instance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ filterwarnings = [
   "ignore::DeprecationWarning:aiosql.*",
   "ignore::DeprecationWarning:litestar.constants.*",
   "ignore::DeprecationWarning:litestar.utils.*",
+  "ignore::DeprecationWarning:httpx._client",
 ]
 testpaths = ["tests"]
 

--- a/src/app/config/app.py
+++ b/src/app/config/app.py
@@ -26,7 +26,7 @@ csrf = CSRFConfig(
 )
 cors = CORSConfig(allow_origins=cast("list[str]", settings.app.ALLOWED_CORS_ORIGINS))
 alchemy = SQLAlchemyAsyncConfig(
-    connection_string=settings.db.URL,
+    engine_instance=settings.db.get_engine(),
     before_send_handler=autocommit_before_send_handler,
     session_config=AsyncSessionConfig(expire_on_commit=False),
     alembic_config=AlembicAsyncConfig(

--- a/src/app/config/base.py
+++ b/src/app/config/base.py
@@ -136,9 +136,6 @@ class DatabaseSettings:
                 json_deserializer=decode_json,
                 echo=self.ECHO,
                 echo_pool=self.ECHO_POOL,
-                max_overflow=self.POOL_MAX_OVERFLOW,
-                pool_size=self.POOL_SIZE,
-                pool_timeout=self.POOL_TIMEOUT,
                 pool_recycle=self.POOL_RECYCLE,
                 pool_pre_ping=self.POOL_PRE_PING,
             )


### PR DESCRIPTION
This PR sets the `SQLAlchemyAsyncConfig` to use the `db_engine` configured from settings.  This ensures things like DB Pool and SQL Print settings are read form the environment correctly. 
