### PR TITLE
test: remove event_loop fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
@@ -8,8 +7,6 @@ import pytest
 from app.config import base
 
 if TYPE_CHECKING:
-    from collections import abc
-
     from pytest import MonkeyPatch
 
 
@@ -20,21 +17,6 @@ pytest_plugins = ["tests.docker_service_fixtures", "tests.data_fixtures"]
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
-
-
-@pytest.fixture(autouse=True, scope="session")
-def event_loop() -> "abc.Iterator[asyncio.AbstractEventLoop]":
-    """Scoped Event loop.
-
-    Need the event loop scoped to the session so that we can use it to check
-    containers are ready in session scoped containers fixture.
-    """
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    try:
-        yield loop
-    finally:
-        loop.close()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
I think this is just an artefact of having used pytest-asyncio in the past.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- 

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- 
