### PR TITLE
fix: signature for _sqla_on_begin method

### DIFF
--- a/src/app/config/base.py
+++ b/src/app/config/base.py
@@ -150,7 +150,7 @@ class DatabaseSettings:
                 dbapi_connection.isolation_level = None
 
             @event.listens_for(engine.sync_engine, "begin")
-            def _sqla_on_begin(dbapi_connection: Any, _: Any) -> Any:  # pragma: no cover
+            def _sqla_on_begin(dbapi_connection: Any) -> Any:  # pragma: no cover
                 """Emits a custom begin"""
                 dbapi_connection.exec_driver_sql("BEGIN")
         else:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ X] Pre-Commit Checks were ran and passed
- [X ] Tests were ran and passed

### Description
Signature of one of the `_sqla_on_begin` method is invalid.

- 

### Close Issue(s)
Fixes #139 


- 
