### PR TITLE
fix: Use to_dict method instead of __dict__ for UserUpdate

### DIFF
--- a/src/app/cli/commands.py
+++ b/src/app/cli/commands.py
@@ -143,7 +143,7 @@ def promote_to_superuser(email: str) -> None:
                 )
                 user = await users_service.update(
                     item_id=user.id,
-                    data=user_in.__dict__,
+                    data=user_in.to_dict(),
                     auto_commit=True,
                 )
                 console.print(f"Upgraded {email} to superuser")


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ X] Pre-Commit Checks were ran and passed
- [ X] Tests were ran and passed

### Description
Fix `app users promote-to-superuser` command not working because of use of `__dict__` instead of `to_dict()` method.
- 

### Close Issue(s)
Fixes #141 
- 
