### PR TITLE
fix: invalid use of isinstance for HTTP exceptions checking

### DIFF
--- a/src/app/lib/exceptions.py
+++ b/src/app/lib/exceptions.py
@@ -131,6 +131,6 @@ def exception_to_http_response(
         http_exc = PermissionDeniedException
     else:
         http_exc = InternalServerException
-    if request.app.debug and not isinstance(http_exc, PermissionDeniedException | NotFoundError | AuthorizationError):
+    if request.app.debug and http_exc not in (PermissionDeniedException, NotFoundError, AuthorizationError):
         return create_debug_response(request, exc)
     return create_exception_response(request, http_exc(detail=str(exc.__cause__)))

--- a/tests/unit/lib/test_exceptions.py
+++ b/tests/unit/lib/test_exceptions.py
@@ -58,14 +58,15 @@ def test_repository_exception_to_http_response(exc: type[ApplicationError], stat
 
 
 @pytest.mark.parametrize(
-    ("exc", "status"),
+    ("exc", "status", "debug"),
     [
-        (exceptions.AuthorizationError, HTTP_403_FORBIDDEN),
-        (exceptions.ApplicationError, HTTP_500_INTERNAL_SERVER_ERROR),
+        (exceptions.AuthorizationError, HTTP_403_FORBIDDEN, True),
+        (exceptions.AuthorizationError, HTTP_403_FORBIDDEN, False),
+        (exceptions.ApplicationError, HTTP_500_INTERNAL_SERVER_ERROR, False),
     ],
 )
-def test_exception_to_http_response(exc: type[exceptions.ApplicationError], status: int) -> None:
-    app = Litestar(route_handlers=[])
+def test_exception_to_http_response(exc: type[exceptions.ApplicationError], status: int, debug: bool) -> None:
+    app = Litestar(route_handlers=[], debug=debug)
     request = RequestFactory(app=app, server="testserver").get("/wherever")
     response = exceptions.exception_to_http_response(request, exc())
     assert response.status_code == status


### PR DESCRIPTION
### Pull Request Checklist

- [X ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ X] Pre-Commit Checks were ran and passed
- [ X] Tests were ran and passed

### Description
I noticed in the `exception_to_http_response` that the way we check for exception was not valid.

We were using `isinstance` on the `http_exc` variable which is a class and not an instance which resulted in getting everytime we were on debug a 500 error even when we were supposed to ignore some exceptions. 


