### PR TITLE
fix: logout now correctly deletes cookie in client

### DIFF
--- a/src/app/domain/accounts/controllers/access.py
+++ b/src/app/domain/accounts/controllers/access.py
@@ -60,10 +60,19 @@ class AccessController(Controller):
     async def logout(
         self,
         request: Request,
-    ) -> None:
+    ) -> Response:
         """Account Logout"""
         request.cookies.pop(auth.key, None)
         request.clear_session()
+
+        response = Response(
+            {"message": "OK"},
+        status_code=200,
+
+        )
+        response.delete_cookie(auth.key)
+
+        return response
 
     @post(
         operation_id="AccountRegister",

--- a/tests/integration/test_access.py
+++ b/tests/integration/test_access.py
@@ -18,3 +18,28 @@ pytestmark = pytest.mark.anyio
 async def test_user_login(client: AsyncClient, username: str, password: str, expected_status_code: int) -> None:
     response = await client.post("/api/access/login", data={"username": username, "password": password})
     assert response.status_code == expected_status_code
+
+
+
+@pytest.mark.parametrize(
+    ("username", "password"),
+    (
+        ("superuser@example.com", "Test_Password1!" ),
+    ),
+)
+async def test_user_logout(client: AsyncClient, username: str, password: str) -> None:
+    response = await client.post("/api/access/login", data={"username": username, "password": password})
+    assert response.status_code == 201
+    cookies = dict(response.cookies)
+
+    assert cookies.get("token") is not None
+
+    me_response = await client.get("/api/me")
+    assert me_response.status_code == 200
+
+    response = await client.post("/api/access/logout")
+    assert response.status_code == 200
+
+    # the user can no longer access the /me route.
+    me_response = await client.get("/api/me")
+    assert me_response.status_code == 401


### PR DESCRIPTION
### Pull Request Checklist

- [X ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ X] Pre-Commit Checks were ran and passed
- [ X] Tests were ran and passed

### Description
The `/api/access/logout` did not remove the cookie set in the clients (e.g browsers). So in a sense it did not allow someone to properyl "logout". 

