### PR TITLE
fix: typo in valkey image name

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -1,6 +1,6 @@
 services:
   cache:
-    image: valkey:valkey
+    image: valkey/valkey:latest
     ports:
       - "16379:6379"
     hostname: cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   cache:
-    image: valkey:valkey
+    image: valkey/valkey:latest
     ports:
       - "16379:6379"
     hostname: cache


### PR DESCRIPTION
Uses the correct name as seen in https://hub.docker.com/r/valkey/valkey/tags