### PR TITLE
get_or_upsert concurrent use

### DIFF
--- a/src/app/config/base.py
+++ b/src/app/config/base.py
@@ -327,7 +327,7 @@ class LogSettings:
     """Log event name for logs from SAQ worker."""
     SAQ_LEVEL: int = 20
     """Level to log SAQ logs."""
-    SQLALCHEMY_LEVEL: int = 20
+    SQLALCHEMY_LEVEL: int = 30
     """Level to log SQLAlchemy logs."""
     UVICORN_ACCESS_LEVEL: int = 20
     """Level to log uvicorn access logs."""

--- a/src/app/config/base.py
+++ b/src/app/config/base.py
@@ -327,7 +327,7 @@ class LogSettings:
     """Log event name for logs from SAQ worker."""
     SAQ_LEVEL: int = 20
     """Level to log SAQ logs."""
-    SQLALCHEMY_LEVEL: int = 30
+    SQLALCHEMY_LEVEL: int = 20
     """Level to log SQLAlchemy logs."""
     UVICORN_ACCESS_LEVEL: int = 20
     """Level to log uvicorn access logs."""

--- a/src/app/db/models/user_role.py
+++ b/src/app/db/models/user_role.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID  # noqa: TCH003
 
 from advanced_alchemy.base import UUIDAuditBase
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -18,7 +18,10 @@ class UserRole(UUIDAuditBase):
     """User Role."""
 
     __tablename__ = "user_account_role"
-    __table_args__ = {"comment": "Links a user to a specific role."}
+    __table_args__ = (
+        UniqueConstraint("user_id", "role_id"),  # Avoid multiple assignments of the same role
+        {"comment": "Links a user to a specific role."},
+    )
     user_id: Mapped[UUID] = mapped_column(ForeignKey("user_account.id", ondelete="cascade"), nullable=False)
     role_id: Mapped[UUID] = mapped_column(ForeignKey("role.id", ondelete="cascade"), nullable=False)
     assigned_at: Mapped[datetime] = mapped_column(default=datetime.now(UTC))

--- a/src/app/domain/accounts/controllers/user_role.py
+++ b/src/app/domain/accounts/controllers/user_role.py
@@ -1,4 +1,5 @@
 """User Routes."""
+
 from __future__ import annotations
 
 from litestar import Controller, post
@@ -44,8 +45,13 @@ class UserRoleController(Controller):
         """Create a new migration role."""
         role_id = (await roles_service.get_one(slug=role_slug)).id
         user_obj = await users_service.get_one(email=data.user_name)
-        if all(user_role.role_id != role_id for user_role in user_obj.roles):
-            obj, created = await user_roles_service.get_or_upsert(role_id=role_id, user_id=user_obj.id)
+        # if all(user_role.role_id != role_id for user_role in user_obj.roles):
+        obj, created = await user_roles_service.get_or_upsert(
+            role_id=role_id,
+            user_id=user_obj.id,
+            # with_for_update=True,
+            # auto_commit=True,
+        )
         if created:
             return Message(message=f"Successfully assigned the '{obj.role_slug}' role to {obj.user_email}.")
         return Message(message=f"User {obj.user_email} already has the '{obj.role_slug}' role.")

--- a/tests/integration/test_account_role.py
+++ b/tests/integration/test_account_role.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
+from httpx import Response
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -66,3 +68,27 @@ async def test_superuser_role_access(
     response = await client.get("/api/teams", headers=user_token_headers)
     assert response.status_code == 200
     assert int(response.json()["total"]) == 0
+
+
+@pytest.mark.parametrize("n_requests", [1, 4])
+async def test_assign_role_concurrent(
+    client: "AsyncClient",
+    superuser_token_headers: dict[str, str],
+    n_requests: int,
+) -> None:
+    async def post() -> Response:
+        return await client.post(
+            "/api/roles/superuser/assign",
+            json={"userName": "user@example.com"},
+            headers=superuser_token_headers,
+        )
+
+    responses = await asyncio.gather(*[post() for _ in range(n_requests)])
+
+    assert all(res.status_code == 201 for res in responses)
+    messages = [res.json()["message"] for res in responses]
+    assert "Successfully assigned the 'superuser' role to user@example.com." in messages
+
+    responses = await asyncio.gather(*[post() for _ in range(n_requests)])
+    messages = [res.json()["message"] for res in responses]
+    assert "User user@example.com already has the 'superuser' role." in messages


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This PR acts as a reproducer for `get_or_upsert` raising `IntegrityErrors` for `UniqueConstraint` when sending multiple requests at once. 

I added a `UniqueConstraint` to the `user_account_role` table which basically means, that one cannot have the same role multiple times.

In the controller I needed to remove the `if` statement, otherwise the get_or_upsert would not create anything in this case. However there's another bug in the original version, as `created` is not defined if the first condition is false.

The test contains 1 or 4 equal queries, two times in a row. When making a single request (which assigns the tag) the second request reports that the role was already assigned and succeeds.
In case of 4 queries at the same time, only the first query succeeds, the remaining three fail.

This PR is not meant to get merged like this, but a starting point for discussion.