### PR TITLE
fix: handle dynamic routes of any depth for WebController

### DIFF
--- a/src/app/domain/web/controllers.py
+++ b/src/app/domain/web/controllers.py
@@ -12,7 +12,7 @@ class WebController(Controller):
     opt = {"exclude_from_auth": True}
 
     @get(
-        path=[constants.SITE_INDEX, f"{constants.SITE_INDEX}/{{path:str}}"],
+        path=[constants.SITE_INDEX, f"{constants.SITE_INDEX}/{{path:path}}"],
         operation_id="WebIndex",
         name="frontend:index",
         status_code=HTTP_200_OK,


### PR DESCRIPTION
## Description

From https://discord.com/channels/919193495116337154/1316783891683610685

Change `path=["/", "/{path:str}"]` to `path=["/", "/{path:path}"]`  in `WebController` to handle requests for all dynamic paths of any depth. It fixes cases where routes like `/posts` are handled but `/posts/1` are not.