### PR TITLE
fix: Team add member

### DIFF
--- a/src/app/domain/teams/controllers/team_member.py
+++ b/src/app/domain/teams/controllers/team_member.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING
 
 from advanced_alchemy.exceptions import IntegrityError
 from litestar import Controller, post
+from litestar.di import Provide
 from litestar.params import Parameter
 
 from app.db import models as m
+from app.domain.accounts.deps import provide_users_service
 from app.domain.teams import urls
 from app.domain.teams.schemas import Team, TeamMemberModify
 from app.domain.teams.services import TeamMemberService, TeamService
@@ -30,6 +32,7 @@ class TeamMemberController(Controller):
             TeamMemberService,
             load=[m.TeamMember.team, m.TeamMember.user],
         ),
+        "users_service": Provide(provide_users_service),
     }
 
     @post(operation_id="AddMemberToTeam", path=urls.TEAM_ADD_MEMBER)

--- a/src/app/domain/teams/services.py
+++ b/src/app/domain/teams/services.py
@@ -107,7 +107,9 @@ class TeamService(SQLAlchemyAsyncRepositoryService[m.Team]):
                     data.tags.remove(tag_rm)
                 data.tags.extend(
                     [
-                        await m.Tag.as_unique_async(self.repository.session, name=tag_text, slug=slugify(tag_text))
+                        await m.Tag.as_unique_async(
+                            self.repository.session, name=tag_text.name, slug=slugify(tag_text.name)
+                        )
                         for tag_text in tags_to_add
                     ],
                 )

--- a/tests/integration/test_teams.py
+++ b/tests/integration/test_teams.py
@@ -87,3 +87,21 @@ async def test_teams_delete(client: "AsyncClient", superuser_token_headers: dict
         headers=superuser_token_headers,
     )
     assert response.status_code == 200
+
+
+async def test_teams_add_remove_member(client: "AsyncClient", superuser_token_headers: dict[str, str]) -> None:
+    response = await client.post(
+        "/api/teams/81108ac1-ffcb-411d-8b1e-d91833999999/members/add",
+        headers=superuser_token_headers,
+        json={"userName": "user@example.com"},
+    )
+    assert response.status_code == 201
+    assert "user@example.com" in [e["email"] for e in response.json()["members"]]
+
+    response = await client.post(
+        "/api/teams/81108ac1-ffcb-411d-8b1e-d91833999999/members/remove",
+        headers=superuser_token_headers,
+        json={"userName": "user@example.com"},
+    )
+    assert response.status_code == 201
+    assert "user@example.com" not in [e["email"] for e in response.json()["members"]]


### PR DESCRIPTION
## Description
This PR adds an unit test to the `teams/<id>/members/add` and `.../remove` endpoints, which are not working currently.

The endpoints were missing the `users_service` dependency, which was added.
In `TeamService` just the `tag_name` is passed to slugify, as this function accepts only strings.