### PR TITLE
fix: avoid encoding twice of jsonb field

### DIFF
--- a/src/app/config/base.py
+++ b/src/app/config/base.py
@@ -103,7 +103,7 @@ class DatabaseSettings:
                 """
 
                 def encoder(bin_value: bytes) -> bytes:
-                    return b"\x01" + encode_json(bin_value)
+                    return b"\x01" + bin_value
 
                 def decoder(bin_value: bytes) -> Any:
                     # the byte is the \x01 prefix for jsonb used by PostgreSQL.


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

The default setup using asyncpg with msgspec as custom json_serializer encode data twice, the data save to database is something like "eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6InZhbHVlMiJ9", base64 encoded  byte string.

The first commit in https://github.com/Priestch/litestar-fullstack/tree/reproduce_bug add a test jsonb model and public controllers, you can test with:
```bash
# insert test jsonb model
curl -X POST http://localhost:8089/api/test-jsonb   -H "Content-Type: application/json"   -d '{
    "name": "test2",
    "data": {"key1": "value1", "key2": "value2"},
    "settings": [{"option": "a", "value": 1}, {"option": "b", "value": 2}]
  }'
  
# test queryed data in controler
curl http://localhost:8089/api/test-jsonb/c4a05c2d-812f-4e6f-9b6e-2cd42658f5d5
  ```
Then checkout to the last commit, testing using same commands.