### PR TITLE
fix(teams): add /accept path to invitation email URL

### DIFF
--- a/src/py/app/domain/teams/listeners.py
+++ b/src/py/app/domain/teams/listeners.py
@@ -71,7 +71,7 @@ async def team_invitation_created_event_handler(invitation_id: UUID, mailer: App
             invitee_email=invitation.email,
             inviter_name=inviter.name or inviter.email,
             team_name=team.name,
-            invitation_url=f"{mailer.base_url}/teams/{team.id}/invitations/{invitation.id}",
+            invitation_url=f"{mailer.base_url}/teams/{team.id}/invitations/{invitation.id}/accept",
         )
 
         await logger.ainfo("Sent team invitation email", invitation_id=invitation.id)


### PR DESCRIPTION
## Summary

- The team invitation email links to `/teams/{id}/invitations/{id}` but the frontend accept page route is at `/teams/{id}/invitations/{id}/accept`
- Without the `/accept` suffix, clicking the link loads the team detail page (or redirects to `/home` if the user isn't a member), instead of showing the accept/decline UI

## Test plan

- [ ] Invite a user to a team
- [ ] Open the invitation email in Mailpit
- [ ] Verify the URL ends with `/accept`
- [ ] Click the link — should show the accept/decline invitation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)