### PR TITLE
fix(teams): commit invitation before emitting event

### DIFF
--- a/src/py/app/domain/teams/controllers/_team_invitation.py
+++ b/src/py/app/domain/teams/controllers/_team_invitation.py
@@ -88,7 +88,7 @@ class TeamInvitationController(Controller):
         payload = data.to_dict()
         payload["team_id"] = team_id
         payload["invited_by"] = current_user
-        db_obj = await team_invitations_service.create(payload)
+        db_obj = await team_invitations_service.create(payload, auto_commit=True)
         request.app.emit(event_id="team_invitation_created", invitation_id=db_obj.id, mailer=app_mailer)
         return team_invitations_service.to_schema(db_obj, schema_type=TeamInvitation)
 


### PR DESCRIPTION
## Summary

- The `team_invitation_created` event listener opens its own DB session via `provide_services()` to look up the invitation
- With `before_send_handler="autocommit"`, the controller's transaction commits on `HTTP_RESPONSE_START`, which races with the listener task dispatched via `app.emit()` (anyio `task_group.start_soon`)
- When the listener wins the race, it queries with a fresh session before the commit, gets `None`, and logs "Could not locate the specified team invitation" — the invitation email is never sent
- Fix: pass `auto_commit=True` to `service.create()` so the row is committed before the event fires

## Test plan

- [ ] Invite a user to a team
- [ ] Check app logs — should show "Sent team invitation email" (not "Could not locate")
- [ ] Verify the invitation email arrives in Mailpit
- [ ] Repeat several times to confirm no intermittent failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)